### PR TITLE
Clear des événements dans l'état EndGame

### DIFF
--- a/game_states/endgame.py
+++ b/game_states/endgame.py
@@ -1,6 +1,7 @@
 #-*-encoding=utf-8-*-
 from datetime import datetime, timedelta
 import json
+import pygame
 
 class EndGame:
     '''Display end game score'''
@@ -26,6 +27,8 @@ class EndGame:
 
     def run(self):
         self.game.screen.fill((0,0,0))
+
+        pygame.event.clear()
 
         if self.winner == -1:
             win_txt = self.game.font.render('It\'s a draw !', 0, (255, 255, 255))


### PR DESCRIPTION
Si on appuie sur les boutons d'action dans l'état `EndGame`, les événements étaient accumulés et utilisées dans l'état suivant (le menu dans ce cas). Donc, si les joueurs appuient accidentellement sur les boutons d'actions à la fin de la partie, c'est le menu qui va recevoir les événements et lancer une nouvelle partie.
