### PR TITLE
CrackGame: Prevent players from dying outside the screen

### DIFF
--- a/minigames/crackgame.py
+++ b/minigames/crackgame.py
@@ -68,7 +68,7 @@ class CrackGame(minigame.Minigame):
                 pygame.draw.aaline(self.screen, (0, 0, 0), (p + crack - 10, self.sidewalk_y+self.sidewalk_height + i*2*self.sidewalk_height), (p + crack - 10, self.sidewalk_y+self.sidewalk_height + i*2*self.sidewalk_height + self.sidewalk_height/5))
                 p += crack
                 if not self.jumping[i]:
-                    if self.positions[i][0] - img.get_rect().width/4 < p < self.positions[i][0] + img.get_rect().width/4:
+                    if (self.positions[i][0] < self.width) and (self.positions[i][0] - img.get_rect().width/4 < p < self.positions[i][0] + img.get_rect().width/4):
                         self.dead[i] = True
 
             if not self.dead[i]:


### PR DESCRIPTION
Il y avait un bug l'an passé qui causait presque toujours la mort des joueurs dans CrackGame une fois que les personnages rencontraient des obstacles passés la limite de l'écran.
Je corrige ça avec un petit one-liner
